### PR TITLE
feat: add support for bank account and brand token payment methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 Format based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+## [2.1.0]
+- Adds support for bank account and brand token payment methods
+
 ## [2.0.4]
 - Fix B2PN value on InquiryRequest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 Format based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
-## [2.1.0]
+## [2.0.5]
 - Adds support for bank account and brand token payment methods
 
 ## [2.0.4]

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ $data = [
     ],
     // Merchant Acknowledgement
     'mack' => 'Y',
+    // Card Related
+    'cardNumber' => '4111111111111111',
+     // M match, N Not match, X unavailable
+    'cvvStatus' => 'X',
+    // MM/YY format
+    'cardExpiration' => '12/20',
     // Payment instrument information
     'instrument' => [
         'type' => 'card',
@@ -125,6 +131,8 @@ $data = [
     'shipmentType' => \PlacetoPay\Kount\Messages\Request::SHIP_SAME,
 ];
 ```
+Card related keys outside the **instrument** key are still supported.
+
 Expected keys for **instrument**:
 
 Card:

--- a/README.md
+++ b/README.md
@@ -89,12 +89,15 @@ $data = [
     ],
     // Merchant Acknowledgement
     'mack' => 'Y',
-    // Card Related
-    'cardNumber' => '4111111111111111',
-    // M match, N Not match, X unavailable
-    'cvvStatus' => 'X',
-    // MM/YY format
-    'cardExpiration' => '12/20',
+    // Payment instrument information
+    'instrument' => [
+        'type' => 'card',
+        'cardNumber' => '4111111111111111',
+         // M match, N Not match, X unavailable
+        'cvvStatus' => 'X',
+        // MM/YY format
+        'cardExpiration' => '12/20',
+    ],
     // Person related
     'payer' => [
         'name' => 'Diego',
@@ -122,6 +125,34 @@ $data = [
     'shipmentType' => \PlacetoPay\Kount\Messages\Request::SHIP_SAME,
 ];
 ```
+Expected keys for **instrument**:
+
+Card:
+```php
+    'instrument' => [
+        'type' => 'card',
+        'cardNumber' => '4111111111111111',
+         // M match, N Not match, X unavailable
+        'cvvStatus' => 'X',
+        // MM/YY format
+        'cardExpiration' => '12/20',
+    ],
+```
+Bank account:
+```php
+    'instrument' => [
+        'type' => 'account',
+        'accountNumber' => '7640014847',
+    ],
+```
+Brand token:
+```php
+    'instrument' => [
+        'type' => 'brand_token',
+        'token' => 'abc123xyz098#',
+    ],
+```
+
 Please try to provide as much information as you can, but there is NOT required shipping, gender, shipmentType, more than 1 item (It has to be at least one), address for payer information
 
 ```php

--- a/src/Constants/SupportedInstruments.php
+++ b/src/Constants/SupportedInstruments.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace PlacetoPay\Kount\Constants;
+
+class SupportedInstruments
+{
+    public const CARD = 'card';
+    public const ACCOUNT = 'account';
+    public const BRAND_TOKEN = 'brand_token';
+}

--- a/src/Messages/InquiryRequest.php
+++ b/src/Messages/InquiryRequest.php
@@ -2,6 +2,8 @@
 
 namespace PlacetoPay\Kount\Messages;
 
+use PlacetoPay\Kount\Constants\SupportedInstruments;
+
 class InquiryRequest extends Request
 {
     private $requestData = [];
@@ -47,28 +49,57 @@ class InquiryRequest extends Request
         }
     }
 
-    private function setPaymentInformation(): void
+    private function getCardData(array $data): array
     {
-        $this->requestData['TOTL'] = $this->parseAmount($this->data['payment']['amount']['total'], $this->data['payment']['amount']['currency']);
-        $this->requestData['CURR'] = $this->data['payment']['amount']['currency'];
-
-        if (!isset($this->data['cardNumber'])) {
-            return;
-        }
-
-        $cardExpiration = explode('/', $this->data['cardExpiration']);
-
-        $this->requestData = array_merge($this->requestData, [
-            'PTOK' => $this->maskCardNumber($this->data['cardNumber']),
-            'LAST4' => substr($this->data['cardNumber'], -4),
+        $cardExpiration = explode('/', $data['cardExpiration']);
+        $cardData = [
+            'PTOK' => $this->maskCardNumber($data['cardNumber']),
+            'LAST4' => substr($data['cardNumber'], -4),
             'PTYP' => 'CARD',
             'PENC' => 'MASK',
             'CCMM' => $cardExpiration[0],
             'CCYY' => '20' . $cardExpiration[1],
-        ]);
+        ];
 
-        if (isset($this->data['cvvStatus'])) {
-            $this->requestData['CVVR'] = $this->data['cvvStatus'];
+        if (isset($data['cvvStatus'])) {
+            $cardData['CVVR'] = $data['cvvStatus'];
+        }
+
+        return $cardData;
+    }
+
+    private function setPaymentInformation(): void
+    {
+        $this->requestData['TOTL'] = $this->parseAmount(
+            $this->data['payment']['amount']['total'],
+            $this->data['payment']['amount']['currency']
+        );
+        $this->requestData['CURR'] = $this->data['payment']['amount']['currency'];
+
+        if (!isset($this->data['cardNumber']) && !isset($this->data['instrument'])) {
+            return;
+        }
+
+        if (isset($this->data['cardNumber'])) {
+            $this->requestData = array_merge($this->requestData, $this->getCardData($this->data));
+        } elseif (isset($this->data['instrument'])) {
+            $instrument = $this->data['instrument'];
+            if ($instrument['type'] === SupportedInstruments::CARD) {
+                $this->requestData = array_merge(
+                    $this->requestData,
+                    $this->getCardData($instrument)
+                );
+            } elseif ($instrument['type'] === SupportedInstruments::ACCOUNT) {
+                $this->requestData = array_merge($this->requestData, [
+                    'PTOK' => $instrument['accountNumber'],
+                    'PTYP' => 'CHEK',
+                ]);
+            } elseif ($instrument['type'] === SupportedInstruments::BRAND_TOKEN) {
+                $this->requestData = array_merge($this->requestData, [
+                    'PTOK' => $instrument['token'],
+                    'PTYP' => 'TOKEN',
+                ]);
+            }
         }
     }
 

--- a/src/Messages/InquiryRequest.php
+++ b/src/Messages/InquiryRequest.php
@@ -7,12 +7,25 @@ use PlacetoPay\Kount\Constants\SupportedInstruments;
 class InquiryRequest extends Request
 {
     private $requestData = [];
+    private array $instrumentData;
 
     public function __construct($session, $data = [])
     {
         parent::__construct($session, $data);
 
         $this->mode = self::MODE_INQUIRY;
+
+        $this->instrumentData = [
+            SupportedInstruments::CARD => function (array $data): array {
+                return $this->getCardData($data);
+            },
+            SupportedInstruments::ACCOUNT => function (array $data): array {
+                return $this->getAccountData($data);
+            },
+            SupportedInstruments::BRAND_TOKEN => function (array $data): array {
+                return $this->getBrandTokenData($data);
+            },
+        ];
     }
 
     public function asRequestData(): array
@@ -68,6 +81,22 @@ class InquiryRequest extends Request
         return $cardData;
     }
 
+    private function getAccountData(array $data): array
+    {
+        return [
+            'PTOK' => $data['accountNumber'],
+            'PTYP' => 'CHEK',
+        ];
+    }
+
+    private function getBrandTokenData(array $data): array
+    {
+        return [
+            'PTOK' => $data['token'],
+            'PTYP' => 'TOKEN',
+        ];
+    }
+
     private function setPaymentInformation(): void
     {
         $this->requestData['TOTL'] = $this->parseAmount(
@@ -76,29 +105,15 @@ class InquiryRequest extends Request
         );
         $this->requestData['CURR'] = $this->data['payment']['amount']['currency'];
 
-        if (!isset($this->data['cardNumber']) && !isset($this->data['instrument'])) {
+        if (isset($this->data['cardNumber'])) {
+            $this->requestData = array_merge($this->requestData, $this->getCardData($this->data));
             return;
         }
 
-        if (isset($this->data['cardNumber'])) {
-            $this->requestData = array_merge($this->requestData, $this->getCardData($this->data));
-        } elseif (isset($this->data['instrument'])) {
-            $instrument = $this->data['instrument'];
-            if ($instrument['type'] === SupportedInstruments::CARD) {
-                $this->requestData = array_merge(
-                    $this->requestData,
-                    $this->getCardData($instrument)
-                );
-            } elseif ($instrument['type'] === SupportedInstruments::ACCOUNT) {
-                $this->requestData = array_merge($this->requestData, [
-                    'PTOK' => $instrument['accountNumber'],
-                    'PTYP' => 'CHEK',
-                ]);
-            } elseif ($instrument['type'] === SupportedInstruments::BRAND_TOKEN) {
-                $this->requestData = array_merge($this->requestData, [
-                    'PTOK' => $instrument['token'],
-                    'PTYP' => 'TOKEN',
-                ]);
+        if (isset($this->data['instrument'])) {
+            $instrument = $this->instrumentData[$this->data['instrument']['type']] ?? null;
+            if (is_callable($instrument)) {
+                $this->requestData = array_merge($this->requestData, call_user_func($instrument, $this->data['instrument']));
             }
         }
     }

--- a/tests/Parsings/ParsingTest.php
+++ b/tests/Parsings/ParsingTest.php
@@ -142,9 +142,9 @@ class ParsingTest extends BaseTestCase
             'CCMM' => '12',
             'CCYY' => '2020',
 
-            'UNIQ' => $data['payer']['documentType'].$data['payer']['document'],
+            'UNIQ' => $data['payer']['documentType'] . $data['payer']['document'],
 
-            'NAME' => $data['payer']['name'].' '.$data['payer']['surname'],
+            'NAME' => $data['payer']['name'] . ' ' . $data['payer']['surname'],
             'GENDER' => $data['gender'],
             'EMAL' => $data['payer']['email'],
             'B2A1' => $data['payer']['address']['street'],
@@ -154,7 +154,7 @@ class ParsingTest extends BaseTestCase
             'B2CC' => $data['payer']['address']['country'],
             'B2PN' => $data['payer']['address']['phone'],
 
-            'S2NM' => $data['payment']['shipping']['name'].' '.$data['payment']['shipping']['surname'],
+            'S2NM' => $data['payment']['shipping']['name'] . ' ' . $data['payment']['shipping']['surname'],
             'S2EM' => $data['payment']['shipping']['email'],
             'S2A1' => $data['payment']['shipping']['address']['street'],
             'S2CI' => $data['payment']['shipping']['address']['city'],
@@ -213,9 +213,9 @@ class ParsingTest extends BaseTestCase
             'CCYY' => '2020',
             'PENC' => 'MASK',
 
-            'UNIQ' => $data['payer']['documentType'].$data['payer']['document'],
+            'UNIQ' => $data['payer']['documentType'] . $data['payer']['document'],
 
-            'NAME' => $data['payer']['name'].' '.$data['payer']['surname'],
+            'NAME' => $data['payer']['name'] . ' ' . $data['payer']['surname'],
             'EMAL' => $data['payer']['email'],
             'B2PN' => $data['payer']['mobile'],
             'PROD_DESC[0]' => $data['payment']['items'][0]['desc'],
@@ -242,7 +242,7 @@ class ParsingTest extends BaseTestCase
                 'amount' => [
                     'total' => 1900,
                     'currency' => 'CLP',
-                ]
+                ],
             ],
         ]);
         $inquiryRequest = $this->service->parseInquiryRequest(5, $data)->asRequestData();
@@ -253,7 +253,7 @@ class ParsingTest extends BaseTestCase
                 'amount' => [
                     'total' => 1900,
                     'currency' => 'JOD',
-                ]
+                ],
             ],
         ]);
         $inquiryRequest = $this->service->parseInquiryRequest(5, $data)->asRequestData();
@@ -264,7 +264,7 @@ class ParsingTest extends BaseTestCase
                 'amount' => [
                     'total' => 1900,
                     'currency' => 'COP',
-                ]
+                ],
             ],
         ]);
         $inquiryRequest = $this->service->parseInquiryRequest(5, $data)->asRequestData();

--- a/tests/Parsings/ParsingTest.php
+++ b/tests/Parsings/ParsingTest.php
@@ -142,9 +142,9 @@ class ParsingTest extends BaseTestCase
             'CCMM' => '12',
             'CCYY' => '2020',
 
-            'UNIQ' => $data['payer']['documentType'] . $data['payer']['document'],
+            'UNIQ' => $data['payer']['documentType'].$data['payer']['document'],
 
-            'NAME' => $data['payer']['name'] . ' ' . $data['payer']['surname'],
+            'NAME' => $data['payer']['name'].' '.$data['payer']['surname'],
             'GENDER' => $data['gender'],
             'EMAL' => $data['payer']['email'],
             'B2A1' => $data['payer']['address']['street'],
@@ -154,7 +154,7 @@ class ParsingTest extends BaseTestCase
             'B2CC' => $data['payer']['address']['country'],
             'B2PN' => $data['payer']['address']['phone'],
 
-            'S2NM' => $data['payment']['shipping']['name'] . ' ' . $data['payment']['shipping']['surname'],
+            'S2NM' => $data['payment']['shipping']['name'].' '.$data['payment']['shipping']['surname'],
             'S2EM' => $data['payment']['shipping']['email'],
             'S2A1' => $data['payment']['shipping']['address']['street'],
             'S2CI' => $data['payment']['shipping']['address']['city'],
@@ -213,9 +213,9 @@ class ParsingTest extends BaseTestCase
             'CCYY' => '2020',
             'PENC' => 'MASK',
 
-            'UNIQ' => $data['payer']['documentType'] . $data['payer']['document'],
+            'UNIQ' => $data['payer']['documentType'].$data['payer']['document'],
 
-            'NAME' => $data['payer']['name'] . ' ' . $data['payer']['surname'],
+            'NAME' => $data['payer']['name'].' '.$data['payer']['surname'],
             'EMAL' => $data['payer']['email'],
             'B2PN' => $data['payer']['mobile'],
             'PROD_DESC[0]' => $data['payment']['items'][0]['desc'],
@@ -237,29 +237,35 @@ class ParsingTest extends BaseTestCase
 
     public function testItParsesCorrectlyAnotherAmounts()
     {
-        $data = $this->basicRequestData(['payment' => [
-            'amount' => [
-                'total' => 1900,
-                'currency' => 'CLP',
-            ]],
+        $data = $this->basicRequestData([
+            'payment' => [
+                'amount' => [
+                    'total' => 1900,
+                    'currency' => 'CLP',
+                ]
+            ],
         ]);
         $inquiryRequest = $this->service->parseInquiryRequest(5, $data)->asRequestData();
         $this->assertEquals(1900, $inquiryRequest['TOTL']);
 
-        $data = $this->basicRequestData(['payment' => [
-            'amount' => [
-                'total' => 1900,
-                'currency' => 'JOD',
-            ]],
+        $data = $this->basicRequestData([
+            'payment' => [
+                'amount' => [
+                    'total' => 1900,
+                    'currency' => 'JOD',
+                ]
+            ],
         ]);
         $inquiryRequest = $this->service->parseInquiryRequest(5, $data)->asRequestData();
         $this->assertEquals(1900000, $inquiryRequest['TOTL']);
 
-        $data = $this->basicRequestData(['payment' => [
-            'amount' => [
-                'total' => 1900,
-                'currency' => 'COP',
-            ]],
+        $data = $this->basicRequestData([
+            'payment' => [
+                'amount' => [
+                    'total' => 1900,
+                    'currency' => 'COP',
+                ]
+            ],
         ]);
         $inquiryRequest = $this->service->parseInquiryRequest(5, $data)->asRequestData();
         $this->assertEquals(190000, $inquiryRequest['TOTL']);
@@ -292,5 +298,66 @@ class ParsingTest extends BaseTestCase
         $inquiryRequest = $this->service->parseInquiryRequest('123', $data);
 
         $this->assertArrayNotHasKey('B2PN', $inquiryRequest->asRequestData());
+    }
+
+    /**
+     * @dataProvider instrumentDataProvider
+     */
+    public function testItParsesInquiryRequestWithInstrument(array $input, array $expected): void
+    {
+        $data = $this->basicRequestData();
+        $data['instrument'] = $input;
+        // Remove card related keys to use the instrument instead.
+        unset($data['cardNumber'], $data['cvvStatus'], $data['cardExpiration']);
+
+        $requestData = $this->service->parseInquiryRequest('123', $data)->asRequestData();
+
+        foreach ($expected as $key => $value) {
+            $this->assertArrayHasKey($key, $requestData);
+            $this->assertEquals($value, $requestData[$key]);
+        }
+    }
+
+    public static function instrumentDataProvider(): array
+    {
+        return [
+            [
+                'input' => [
+                    'type' => 'card',
+                    'cardNumber' => '4111111111111111',
+                    'cvvStatus' => 'X',
+                    'cardExpiration' => '12/24',
+                ],
+                'expected' => [
+                    'PTOK' => '411111XXXXXX1111',
+                    'LAST4' => '1111',
+                    'PTYP' => 'CARD',
+                    'PENC' => 'MASK',
+                    'CCMM' => '12',
+                    'CCYY' => '2024',
+                    'CVVR' => 'X',
+                ],
+            ],
+            [
+                'input' => [
+                    'type' => 'account',
+                    'accountNumber' => '1234567890',
+                ],
+                'expected' => [
+                    'PTOK' => '1234567890',
+                    'PTYP' => 'CHEK',
+                ],
+            ],
+            [
+                'input' => [
+                    'type' => 'brand_token',
+                    'token' => 'some-random-token',
+                ],
+                'expected' => [
+                    'PTOK' => 'some-random-token',
+                    'PTYP' => 'TOKEN',
+                ],
+            ],
+        ];
     }
 }


### PR DESCRIPTION
Adds the key _instrument_ to the InquiryRequest data, this will contains the payment instrument information. It can receive card, account or brand_token data.
Keeps support of _cardNumber_ outside the _instrument_ key.