### PR TITLE
feat: V1 - add support for bank account and brand token payment methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 Format based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.3.0]
+## [1.2.1]
 - Adds support for bank account and brand token payment methods
 
 ## [1.2.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 Format based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.3.0]
+- Adds support for bank account and brand token payment methods
+
 ## [1.2.0]
 - Adds PHP 8.0 support
 

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,7 @@
 ## Installation
 
 This SDK can be installed easily through composer
+
 ```
 composer require placetopay/kount
 ```
@@ -19,12 +20,17 @@ $service = new \PlacetoPay\Kount\KountService([
 
 ### Data Collector
 
-First on the page where the credit card information will be gathered you need to place the iframe for the data collector, make sure to replace YOUR_WEBPAGE_URL, YOUR_MERCHANT and THE_SESSION for the payment
+First on the page where the credit card information will be gathered you need to place the iframe for the data
+collector, make sure to replace YOUR_WEBPAGE_URL, YOUR_MERCHANT and THE_SESSION for the payment
 
-Note: It HAS to be over HTTPS, and it does NOT has to be on the root of your url, you can use https://YOUR_WEBPAGE_URL/kount/something/logo.htm, and I'm not entirely sure that it needs to call logo.htm and logo.gif, but I'm using those names anyway
+Note: It HAS to be over HTTPS, and it does NOT has to be on the root of your url, you can
+use https://YOUR_WEBPAGE_URL/kount/something/logo.htm, and I'm not entirely sure that it needs to call logo.htm and
+logo.gif, but I'm using those names anyway
 
 ```html
-<iframe width=1 height=1 frameborder=0 scrolling=no src="https://YOUR_WEBPAGE_URL/logo.htm?m=YOUR_MERCHANT&s=THE_SESSION">
+
+<iframe width=1 height=1 frameborder=0 scrolling=no
+        src="https://YOUR_WEBPAGE_URL/logo.htm?m=YOUR_MERCHANT&s=THE_SESSION">
     <img width=1 height=1 src="https://YOUR_WEBPAGE_URL/logo.gif?m=YOUR_MERCHANT&s=THE_SESSION">
 </iframe>
 ```
@@ -38,7 +44,9 @@ Route::get('/kount/{slug?}', function($slug = null) {
 });
 ```
 
-This example it's made with Laravel, but the principle it's the same, slug its the logo.htm or logo.gif part, and the session it's captured through the GET variable, the merchant it's not required because it has been set on the initialization of the service
+This example it's made with Laravel, but the principle it's the same, slug its the logo.htm or logo.gif part, and the
+session it's captured through the GET variable, the merchant it's not required because it has been set on the
+initialization of the service
 
 Once this it's done, the data collector will be working just fine.
 
@@ -89,12 +97,15 @@ $data = [
     ],
     // Merchant Acknowledgement
     'mack' => 'Y',
-    // Card Related
-    'cardNumber' => '4111111111111111',
-    // M match, N Not match, X unavailable
-    'cvvStatus' => 'X',
-    // MM/YY format
-    'cardExpiration' => '12/20',
+    // Payment instrument information
+    'instrument' => [
+        'type' => 'card',
+        'cardNumber' => '4111111111111111',
+        // M match, N Not match, X unavailable
+        'cvvStatus' => 'X',
+        // MM/YY format
+        'cardExpiration' => '12/20',
+    ],
     // Person related
     'payer' => [
         'name' => 'John',
@@ -122,7 +133,42 @@ $data = [
     'shipmentType' => \PlacetoPay\Kount\Messages\Request::SHIP_SAME,
 ];
 ```
-Please try to provide as much information as you can, but there is NOT required shipping, gender, shipmentType, more than 1 item (It has to be at least one), address for payer information
+
+Expected keys for **instrument**:
+
+Card:
+
+```php
+    'instrument' => [
+        'type' => 'card',
+        'cardNumber' => '4111111111111111',
+         // M match, N Not match, X unavailable
+        'cvvStatus' => 'X',
+        // MM/YY format
+        'cardExpiration' => '12/20',
+    ],
+```
+
+Bank account:
+
+```php
+    'instrument' => [
+        'type' => 'account',
+        'accountNumber' => '7640014847',
+    ],
+```
+
+Brand token:
+
+```php
+    'instrument' => [
+        'type' => 'brand_token',
+        'token' => 'abc123xyz098#',
+    ],
+```
+
+Please try to provide as much information as you can, but there is NOT required shipping, gender, shipmentType, more
+than 1 item (It has to be at least one), address for payer information
 
 ```
 try {
@@ -145,7 +191,8 @@ try {
 
 ### Available response information
 
-The response object provides a convenient structure and methods that allow you to get all the information returned by Kount.
+The response object provides a convenient structure and methods that allow you to get all the information returned by
+Kount.
 
 ```php
 $response->score();         //  33
@@ -267,6 +314,7 @@ $response->system->toArray();
 ```
 
 #### Decision information
+
 ```php
 $response->decision->code();             //  'D'
 $response->decision->description();      //  'DECLINE'
@@ -286,6 +334,7 @@ $response->decision->toArray();
 ```
 
 #### Verification result
+
 ```php
 $response->verification->geolocationCountry();                     //  'US'
 $response->verification->geolocationRegion();                      //  'EAST'
@@ -309,6 +358,7 @@ $response->verification->toArray();
 ```
 
 #### Transaction information
+
 ```php
 $response->transaction->id();                                // 'P01J0KZN329Z'
 $response->transaction->usedCardsCount();                    // 1
@@ -365,8 +415,8 @@ $response->transaction->toArray();
  */
 ```
 
-
 #### Transaction IP information
+
 ```php
 $response->ip->address();          //  '181.128.85.221'
 $response->ip->latitude();         //  '6.2518'
@@ -487,6 +537,7 @@ $response->errors->toArray();
 ```
 
 #### Additional information
+
 ```php
 $response->additional->dateSinceFirstMadeTransaction();     //  '2017-05-30'
 $response->additional->screenResolution();                  //  '768x1366'
@@ -509,7 +560,8 @@ $response->additional->toArray();
 
 ### Mocked responses
 
-If you change the client on the settings for the mock client the responses would be mocked ones and the real service will not be used
+If you change the client on the settings for the mock client the responses would be mocked ones and the real service
+will not be used
 
 ```
 return new KountService([
@@ -518,7 +570,8 @@ return new KountService([
 ]);
 ```
 
-After this mock instance is loaded the available options to mock are this ones. Those are passed via `payment.reference`, meaning the reference on the transaction
+After this mock instance is loaded the available options to mock are this ones. Those are passed via
+`payment.reference`, meaning the reference on the transaction
 
 * AUTH_ERR - Simulates a bad or expired ApiKey
 * REVIEW - Simulates a review response

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,6 @@
 ## Installation
 
 This SDK can be installed easily through composer
-
 ```
 composer require placetopay/kount
 ```
@@ -20,17 +19,12 @@ $service = new \PlacetoPay\Kount\KountService([
 
 ### Data Collector
 
-First on the page where the credit card information will be gathered you need to place the iframe for the data
-collector, make sure to replace YOUR_WEBPAGE_URL, YOUR_MERCHANT and THE_SESSION for the payment
+First on the page where the credit card information will be gathered you need to place the iframe for the data collector, make sure to replace YOUR_WEBPAGE_URL, YOUR_MERCHANT and THE_SESSION for the payment
 
-Note: It HAS to be over HTTPS, and it does NOT has to be on the root of your url, you can
-use https://YOUR_WEBPAGE_URL/kount/something/logo.htm, and I'm not entirely sure that it needs to call logo.htm and
-logo.gif, but I'm using those names anyway
+Note: It HAS to be over HTTPS, and it does NOT has to be on the root of your url, you can use https://YOUR_WEBPAGE_URL/kount/something/logo.htm, and I'm not entirely sure that it needs to call logo.htm and logo.gif, but I'm using those names anyway
 
 ```html
-
-<iframe width=1 height=1 frameborder=0 scrolling=no
-        src="https://YOUR_WEBPAGE_URL/logo.htm?m=YOUR_MERCHANT&s=THE_SESSION">
+<iframe width=1 height=1 frameborder=0 scrolling=no src="https://YOUR_WEBPAGE_URL/logo.htm?m=YOUR_MERCHANT&s=THE_SESSION">
     <img width=1 height=1 src="https://YOUR_WEBPAGE_URL/logo.gif?m=YOUR_MERCHANT&s=THE_SESSION">
 </iframe>
 ```
@@ -44,9 +38,7 @@ Route::get('/kount/{slug?}', function($slug = null) {
 });
 ```
 
-This example it's made with Laravel, but the principle it's the same, slug its the logo.htm or logo.gif part, and the
-session it's captured through the GET variable, the merchant it's not required because it has been set on the
-initialization of the service
+This example it's made with Laravel, but the principle it's the same, slug its the logo.htm or logo.gif part, and the session it's captured through the GET variable, the merchant it's not required because it has been set on the initialization of the service
 
 Once this it's done, the data collector will be working just fine.
 
@@ -191,8 +183,7 @@ try {
 
 ### Available response information
 
-The response object provides a convenient structure and methods that allow you to get all the information returned by
-Kount.
+The response object provides a convenient structure and methods that allow you to get all the information returned by Kount.
 
 ```php
 $response->score();         //  33
@@ -314,7 +305,6 @@ $response->system->toArray();
 ```
 
 #### Decision information
-
 ```php
 $response->decision->code();             //  'D'
 $response->decision->description();      //  'DECLINE'
@@ -334,7 +324,6 @@ $response->decision->toArray();
 ```
 
 #### Verification result
-
 ```php
 $response->verification->geolocationCountry();                     //  'US'
 $response->verification->geolocationRegion();                      //  'EAST'
@@ -358,7 +347,6 @@ $response->verification->toArray();
 ```
 
 #### Transaction information
-
 ```php
 $response->transaction->id();                                // 'P01J0KZN329Z'
 $response->transaction->usedCardsCount();                    // 1
@@ -415,8 +403,8 @@ $response->transaction->toArray();
  */
 ```
 
-#### Transaction IP information
 
+#### Transaction IP information
 ```php
 $response->ip->address();          //  '181.128.85.221'
 $response->ip->latitude();         //  '6.2518'
@@ -537,7 +525,6 @@ $response->errors->toArray();
 ```
 
 #### Additional information
-
 ```php
 $response->additional->dateSinceFirstMadeTransaction();     //  '2017-05-30'
 $response->additional->screenResolution();                  //  '768x1366'
@@ -560,8 +547,7 @@ $response->additional->toArray();
 
 ### Mocked responses
 
-If you change the client on the settings for the mock client the responses would be mocked ones and the real service
-will not be used
+If you change the client on the settings for the mock client the responses would be mocked ones and the real service will not be used
 
 ```
 return new KountService([
@@ -570,8 +556,7 @@ return new KountService([
 ]);
 ```
 
-After this mock instance is loaded the available options to mock are this ones. Those are passed via
-`payment.reference`, meaning the reference on the transaction
+After this mock instance is loaded the available options to mock are this ones. Those are passed via `payment.reference`, meaning the reference on the transaction
 
 * AUTH_ERR - Simulates a bad or expired ApiKey
 * REVIEW - Simulates a review response

--- a/src/Constants/SupportedInstruments.php
+++ b/src/Constants/SupportedInstruments.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace PlacetoPay\Kount\Constants;
+
+class SupportedInstruments
+{
+    public const CARD = 'card';
+    public const ACCOUNT = 'account';
+    public const BRAND_TOKEN = 'brand_token';
+}

--- a/src/Messages/InquiryRequest.php
+++ b/src/Messages/InquiryRequest.php
@@ -2,15 +2,30 @@
 
 namespace PlacetoPay\Kount\Messages;
 
+use PlacetoPay\Kount\Constants\SupportedInstruments;
+
 class InquiryRequest extends Request
 {
     private $requestData = [];
+    private array $instrumentData;
 
     public function __construct($session, $data = [])
     {
         parent::__construct($session, $data);
 
         $this->mode = self::MODE_INQUIRY;
+
+        $this->instrumentData = [
+            SupportedInstruments::CARD => function (array $data): array {
+                return $this->getCardData($data);
+            },
+            SupportedInstruments::ACCOUNT => function (array $data): array {
+                return $this->getAccountData($data);
+            },
+            SupportedInstruments::BRAND_TOKEN => function (array $data): array {
+                return $this->getBrandTokenData($data);
+            },
+        ];
     }
 
     public function asRequestData(): array
@@ -47,28 +62,59 @@ class InquiryRequest extends Request
         }
     }
 
-    private function setPaymentInformation(): void
+    private function getCardData(array $data): array
     {
-        $this->requestData['TOTL'] = $this->parseAmount($this->data['payment']['amount']['total'], $this->data['payment']['amount']['currency']);
-        $this->requestData['CURR'] = $this->data['payment']['amount']['currency'];
-
-        if (!isset($this->data['cardNumber'])) {
-            return;
-        }
-
-        $cardExpiration = explode('/', $this->data['cardExpiration']);
-
-        $this->requestData = array_merge($this->requestData, [
-            'PTOK' => $this->maskCardNumber($this->data['cardNumber']),
-            'LAST4' => substr($this->data['cardNumber'], -4),
+        $cardExpiration = explode('/', $data['cardExpiration']);
+        $cardData = [
+            'PTOK' => $this->maskCardNumber($data['cardNumber']),
+            'LAST4' => substr($data['cardNumber'], -4),
             'PTYP' => 'CARD',
             'PENC' => 'MASK',
             'CCMM' => $cardExpiration[0],
             'CCYY' => '20' . $cardExpiration[1],
-        ]);
+        ];
 
-        if (isset($this->data['cvvStatus'])) {
-            $this->requestData['CVVR'] = $this->data['cvvStatus'];
+        if (isset($data['cvvStatus'])) {
+            $cardData['CVVR'] = $data['cvvStatus'];
+        }
+
+        return $cardData;
+    }
+
+    private function getAccountData(array $data): array
+    {
+        return [
+            'PTOK' => $data['accountNumber'],
+            'PTYP' => 'CHEK',
+        ];
+    }
+
+    private function getBrandTokenData(array $data): array
+    {
+        return [
+            'PTOK' => $data['token'],
+            'PTYP' => 'TOKEN',
+        ];
+    }
+
+    private function setPaymentInformation(): void
+    {
+        $this->requestData['TOTL'] = $this->parseAmount(
+            $this->data['payment']['amount']['total'],
+            $this->data['payment']['amount']['currency']
+        );
+        $this->requestData['CURR'] = $this->data['payment']['amount']['currency'];
+
+        if (isset($this->data['cardNumber'])) {
+            $this->requestData = array_merge($this->requestData, $this->getCardData($this->data));
+            return;
+        }
+
+        if (isset($this->data['instrument'])) {
+            $instrument = $this->instrumentData[$this->data['instrument']['type']] ?? null;
+            if (is_callable($instrument)) {
+                $this->requestData = array_merge($this->requestData, call_user_func($instrument, $this->data['instrument']));
+            }
         }
     }
 

--- a/tests/Parsings/ParsingTest.php
+++ b/tests/Parsings/ParsingTest.php
@@ -294,4 +294,65 @@ class ParsingTest extends BaseTestCase
 
         $this->assertArrayNotHasKey('B2PN', $inquiryRequest->asRequestData());
     }
+
+    /**
+     * @dataProvider instrumentDataProvider
+     */
+    public function testItParsesInquiryRequestWithInstrument(array $input, array $expected): void
+    {
+        $data = $this->basicRequestData();
+        $data['instrument'] = $input;
+        // Remove card related keys to use the instrument instead.
+        unset($data['cardNumber'], $data['cvvStatus'], $data['cardExpiration']);
+
+        $requestData = $this->service->parseInquiryRequest('123', $data)->asRequestData();
+
+        foreach ($expected as $key => $value) {
+            $this->assertArrayHasKey($key, $requestData);
+            $this->assertEquals($value, $requestData[$key]);
+        }
+    }
+
+    public static function instrumentDataProvider(): array
+    {
+        return [
+            [
+                'input' => [
+                    'type' => 'card',
+                    'cardNumber' => '4111111111111111',
+                    'cvvStatus' => 'X',
+                    'cardExpiration' => '12/24',
+                ],
+                'expected' => [
+                    'PTOK' => '411111XXXXXX1111',
+                    'LAST4' => '1111',
+                    'PTYP' => 'CARD',
+                    'PENC' => 'MASK',
+                    'CCMM' => '12',
+                    'CCYY' => '2024',
+                    'CVVR' => 'X',
+                ],
+            ],
+            [
+                'input' => [
+                    'type' => 'account',
+                    'accountNumber' => '1234567890',
+                ],
+                'expected' => [
+                    'PTOK' => '1234567890',
+                    'PTYP' => 'CHEK',
+                ],
+            ],
+            [
+                'input' => [
+                    'type' => 'brand_token',
+                    'token' => 'some-random-token',
+                ],
+                'expected' => [
+                    'PTOK' => 'some-random-token',
+                    'PTYP' => 'TOKEN',
+                ],
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Adds the key _instrument_ to the InquiryRequest data, this will contains the payment instrument information. It can receive card, account or brand_token data.
Keeps support of cardNumber outside the instrument key.